### PR TITLE
[Feat/#24] 희망 배송날짜 선택 페이지 컴포넌트 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@emotion/react": "^11.13.3",
     "jotai": "^2.9.3",
     "react": "^18.3.1",
+    "react-calendar": "^5.0.0",
     "react-daum-postcode": "^3.1.3",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.26.1"

--- a/src/components/common/CustomCalendar/CustomCalendar.tsx
+++ b/src/components/common/CustomCalendar/CustomCalendar.tsx
@@ -1,0 +1,106 @@
+import "react-calendar/dist/Calendar.css";
+import Calendar, { CalendarProps } from "react-calendar";
+import { useState } from "react";
+
+interface CustomCalendarProps {
+  onDateChange: (date: string) => void;
+}
+
+const CustomCalendar = ({ onDateChange }: CustomCalendarProps) => {
+  const [date, setDate] = useState<Date | null>(new Date());
+
+  const formatDay = (locale: string | undefined, date: Date): string =>
+    date.getDate().toString();
+
+  const formatDate = (date: Date) => {
+    const formattedDate = date
+      .toLocaleDateString("ko-KR", {
+        year: "numeric",
+        month: "2-digit",
+        day: "2-digit",
+      })
+      .replace(/\./g, "-")
+      .replace(/\s/g, "");
+    return formattedDate.endsWith("-")
+      ? formattedDate.slice(0, -1)
+      : formattedDate;
+  };
+
+  const handleDateChange: CalendarProps["onChange"] = (value) => {
+    if (value instanceof Date) {
+      const formattedDate = formatDate(value);
+      setDate(value);
+      onDateChange(formattedDate);
+    } else if (
+      Array.isArray(value) &&
+      value.length > 0 &&
+      value[0] instanceof Date
+    ) {
+      const formattedDate = formatDate(value[0]);
+      setDate(value[0]);
+      onDateChange(formattedDate);
+    }
+  };
+
+  const calendarStyles = {
+    ".react-calendar": {
+      width: "100%",
+      border: "1px solid #000",
+      borderRadius: "10px",
+      padding: "1rem",
+    },
+    ".react-calendar__navigation": {
+      justifyContent: "flex-start",
+      button: {
+        fontSize: "1.8rem",
+      },
+    },
+    ".react-calendar__month-view__weekdays": {
+      padding: "1rem 0",
+    },
+    ".react-calendar__month-view__weekdays abbr": {
+      textDecoration: "none",
+      fontSize: "1.2rem",
+      fontWeight: 400,
+      color: "#6B6F77",
+    },
+    ".react-calendar__tile": {
+      padding: "1.4rem 6.7px",
+      background: "none",
+      fontSize: "1.6rem",
+      fontWeight: "500",
+
+      "&:hover": {
+        color: "white",
+        backgroundColor: "#EC6732",
+        borderRadius: "10px",
+      },
+      "&.react-calendar__tile--active": {
+        color: "white",
+        backgroundColor: "#EC6732",
+        borderRadius: "10px",
+      },
+      "&.react-calendar__tile--now": {
+        color: "white",
+        backgroundColor: "#EC6732",
+        opacity: "0.4",
+        borderRadius: "10px",
+      },
+    },
+    ".react-calendar__tile--active": {
+      //   color: "#4285F4",
+    },
+  };
+
+  return (
+    <div css={calendarStyles}>
+      <Calendar
+        onChange={handleDateChange}
+        value={date}
+        formatDay={formatDay}
+      />
+    </div>
+  );
+};
+
+export default CustomCalendar;

--- a/src/components/common/RadioInput/RadioInput.style.ts
+++ b/src/components/common/RadioInput/RadioInput.style.ts
@@ -19,6 +19,7 @@ export const radioLabelStyle = (theme: Theme) => css`
     border-radius: 50%;
     width: 1.6rem;
     height: 1.6rem;
+    cursor: pointer;
   }
 
   input[type="radio"]:checked {

--- a/src/components/common/RadioInput/RadioInput.style.ts
+++ b/src/components/common/RadioInput/RadioInput.style.ts
@@ -1,0 +1,32 @@
+import { Theme, css } from "@emotion/react";
+import { flexGenerator } from "@styles/generator";
+
+export const radioLabelStyle = (theme: Theme) => css`
+  ${flexGenerator()}
+  gap: 0.1rem;
+  padding: 0;
+  cursor: pointer;
+
+  input[type="radio"],
+  span {
+    vertical-align: middle;
+    ${theme.font["subhead-n-14"]}
+  }
+
+  input[type="radio"] {
+    appearance: none;
+    border: 1px solid ${theme.color.black};
+    border-radius: 50%;
+    width: 1.6rem;
+    height: 1.6rem;
+  }
+
+  input[type="radio"]:checked {
+    background-color: ${theme.color.white};
+    border: 4px solid ${theme.color.orange};
+  }
+`;
+
+export const labelSpanStyle = (theme: Theme) => css`
+  color: ${theme.color.black};
+`;

--- a/src/components/common/RadioInput/RadioInput.tsx
+++ b/src/components/common/RadioInput/RadioInput.tsx
@@ -1,0 +1,33 @@
+import React, { HTMLAttributes } from "react";
+import { labelSpanStyle, radioLabelStyle } from "./RadioInput.style";
+
+export interface RadioInputProps extends HTMLAttributes<HTMLInputElement> {
+  value: string;
+  name: string;
+  checked: boolean;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  label: string;
+}
+
+const RadioInput = ({
+  value,
+  name,
+  checked,
+  onChange,
+  label,
+}: RadioInputProps) => {
+  return (
+    <label css={radioLabelStyle}>
+      <input
+        type="radio"
+        value={value}
+        name={name}
+        checked={checked}
+        onChange={onChange}
+      />
+      <span css={labelSpanStyle}>{label}</span>
+    </label>
+  );
+};
+
+export default RadioInput;

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -4,5 +4,14 @@ import ProgressBar from "./ProgressBar/ProgressBar";
 import Input from "./Input/Input";
 import CheckBox from "./CheckBox/CheckBox";
 import CountProduct from "./CountProduct/CountProduct";
+import RadioInput from "./RadioInput/RadioInput";
 
-export { Button, Header, ProgressBar, Input, CheckBox, CountProduct };
+export {
+  Button,
+  Header,
+  ProgressBar,
+  Input,
+  CheckBox,
+  CountProduct,
+  RadioInput,
+};

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -5,6 +5,7 @@ import Input from "./Input/Input";
 import CheckBox from "./CheckBox/CheckBox";
 import CountProduct from "./CountProduct/CountProduct";
 import RadioInput from "./RadioInput/RadioInput";
+import CustomCalendar from "./CustomCalendar/CustomCalendar";
 
 export {
   Button,
@@ -14,4 +15,5 @@ export {
   CheckBox,
   CountProduct,
   RadioInput,
+  CustomCalendar,
 };

--- a/src/pages/orderInfo/components/steps/CheckInfo/CheckInfo.tsx
+++ b/src/pages/orderInfo/components/steps/CheckInfo/CheckInfo.tsx
@@ -1,7 +1,10 @@
 import { Header, ProgressBar } from "@components";
+import { useOrderPostDataChange } from "@pages/orderInfo/hooks/useOrderPostDataChange";
 import { StepProps } from "@types";
 
 const CheckInfo = ({ onNext }: StepProps) => {
+  const { orderPostDataState } = useOrderPostDataChange();
+  console.log(orderPostDataState);
   return (
     <div onClick={onNext}>
       <Header text="입력 정보 확인" />

--- a/src/pages/orderInfo/components/steps/SelectDeliveryDate/SelectDeliveryDate.style.ts
+++ b/src/pages/orderInfo/components/steps/SelectDeliveryDate/SelectDeliveryDate.style.ts
@@ -1,0 +1,31 @@
+import { Theme } from "@emotion/react";
+import { css } from "@emotion/react";
+import { flexGenerator } from "@styles/generator";
+
+export const mainSectionStyle = css`
+  ${flexGenerator("column", "start", "start")}
+  gap: 3.6rem;
+  width: 100%;
+  margin-top: 2.8rem;
+`;
+
+export const radioWrapper = css`
+  ${flexGenerator()};
+  gap: 1rem;
+`;
+
+export const textWrapper = css`
+  ${flexGenerator("column", "start", "start")}
+  gap: 2.8rem;
+  width: 100%;
+`;
+
+export const normalText = (theme: Theme) => css`
+  ${theme.font["subhead-n-14"]}
+  color: ${theme.color.black};
+`;
+
+export const boldText = (theme: Theme) => css`
+  ${theme.font["subhead-b-14"]}
+  color: ${theme.color.black};
+`;

--- a/src/pages/orderInfo/components/steps/SelectDeliveryDate/SelectDeliveryDate.tsx
+++ b/src/pages/orderInfo/components/steps/SelectDeliveryDate/SelectDeliveryDate.tsx
@@ -1,12 +1,85 @@
-import { Header, ProgressBar } from "@components";
+import { Button, Header, ProgressBar, RadioInput } from "@components";
+import {
+  buttonSectionStyle,
+  layoutStyle,
+  orangeTextStyle,
+  sectionStyle,
+  textStyle,
+} from "@pages/orderInfo/styles";
 import { StepProps } from "@types";
+import {
+  boldText,
+  mainSectionStyle,
+  normalText,
+  radioWrapper,
+  textWrapper,
+} from "./SelectDeliveryDate.style";
+import React, { useState } from "react";
 
 const SelectDeliveryDate = ({ onNext }: StepProps) => {
+  const [selectedOption, setSelectedOption] = useState("regular");
+
+  const handleOptionChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setSelectedOption(e.target.value);
+  };
+  const handleNextClick = () => {
+    onNext();
+  };
   return (
-    <div onClick={onNext}>
+    <>
       <Header text="희망 배송일자 선택" />
       <ProgressBar progress={71.4} />
-    </div>
+      <div css={layoutStyle}>
+        <section css={sectionStyle}>
+          <div css={textStyle}>
+            희망하는
+            <br />
+            <span css={orangeTextStyle}>배송일자</span>를 선택해주세요
+          </div>
+        </section>
+        <main css={mainSectionStyle}>
+          <section css={radioWrapper}>
+            <RadioInput
+              name="delivery"
+              value="regular"
+              checked={selectedOption === "regular"}
+              onChange={handleOptionChange}
+              label="일반 배송"
+            />
+            <RadioInput
+              name="delivery"
+              value="scheduled"
+              checked={selectedOption === "scheduled"}
+              onChange={handleOptionChange}
+              label="예약 배송"
+            />
+          </section>
+          <section css={textWrapper}>
+            <span css={normalText}>
+              {selectedOption === "regular"
+                ? "일반배송은 가능한 가장 빠른 날짜에 발송해드려요."
+                : "예약배송은 원하시는 날짜에 맞춰 발송해드려요."}
+            </span>
+            <span>
+              {selectedOption === "regular" && (
+                <span css={normalText}>
+                  보통 배송 출발까지 2일정도 소요되지만,
+                  <br />
+                </span>
+              )}
+              <span css={boldText}>
+                기상 상황에 따라 일정이 변동될 수 있어요.
+              </span>
+            </span>
+          </section>
+        </main>
+        <footer css={buttonSectionStyle}>
+          <Button variant="fill" onClick={handleNextClick}>
+            다음
+          </Button>
+        </footer>
+      </div>
+    </>
   );
 };
 

--- a/src/pages/orderInfo/components/steps/SelectDeliveryDate/SelectDeliveryDate.tsx
+++ b/src/pages/orderInfo/components/steps/SelectDeliveryDate/SelectDeliveryDate.tsx
@@ -1,4 +1,10 @@
-import { Button, Header, ProgressBar, RadioInput } from "@components";
+import {
+  Button,
+  CustomCalendar,
+  Header,
+  ProgressBar,
+  RadioInput,
+} from "@components";
 import {
   buttonSectionStyle,
   layoutStyle,
@@ -15,14 +21,26 @@ import {
   textWrapper,
 } from "./SelectDeliveryDate.style";
 import React, { useState } from "react";
+import { useOrderPostDataChange } from "@pages/orderInfo/hooks/useOrderPostDataChange";
 
 const SelectDeliveryDate = ({ onNext }: StepProps) => {
+  const { handleRecipientInputChange } = useOrderPostDataChange();
   const [selectedOption, setSelectedOption] = useState("regular");
+  const [selectedDate, setSelectedDate] = useState("");
 
   const handleOptionChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setSelectedOption(e.target.value);
   };
+  const handleDateChange = (date: string) => {
+    setSelectedDate(date);
+  };
   const handleNextClick = () => {
+    if (selectedOption !== "regular" && selectedDate.length < 1) {
+      alert("희망 배송일자를 선택해주세요");
+      return;
+    }
+
+    handleRecipientInputChange(selectedDate, "deliveryDate");
     onNext();
   };
   return (
@@ -72,6 +90,9 @@ const SelectDeliveryDate = ({ onNext }: StepProps) => {
               </span>
             </span>
           </section>
+          {selectedOption === "scheduled" && (
+            <CustomCalendar onDateChange={handleDateChange} />
+          )}
         </main>
         <footer css={buttonSectionStyle}>
           <Button variant="fill" onClick={handleNextClick}>

--- a/src/pages/orderInfo/hooks/useOrderPostDataChange.ts
+++ b/src/pages/orderInfo/hooks/useOrderPostDataChange.ts
@@ -32,11 +32,17 @@ export const useOrderPostDataChange = () => {
   };
 
   const handleRecipientInputChange = (
-    e: React.ChangeEvent<HTMLInputElement>,
+    e: React.ChangeEvent<HTMLInputElement> | string,
     key: keyof RecipientInfo
   ) => {
-    let value = e.target.value;
-    
+    let value: string;
+
+    if (typeof e === "string") {
+      value = e;
+    } else {
+      value = e.target.value;
+    }
+
     if (key === "recipientPhone") {
       value = formatPhoneNumber(value);
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -857,6 +857,11 @@
   dependencies:
     "@swc/core" "^1.5.7"
 
+"@wojtekmaj/date-utils@^1.1.3":
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/@wojtekmaj/date-utils/-/date-utils-1.5.1.tgz#c3cd67177ac781cfa5736219d702a55a2aea5f2b"
+  integrity sha512-+i7+JmNiE/3c9FKxzWFi2IjRJ+KzZl1QPu6QNrsgaa2MuBgXvUy4gA1TVzf/JMdIIloB76xSKikTWuyYAIVLww==
+
 acorn-jsx@^5.3.2:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
@@ -978,6 +983,11 @@ chalk@^4.0.0:
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
+
+clsx@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-2.1.1.tgz#eed397c9fd8bd882bfb18deab7102049a2f32999"
+  integrity sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==
 
 color-convert@^1.9.0:
   version "1.9.3"
@@ -1328,6 +1338,13 @@ gensync@^1.0.0-beta.2:
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"
   integrity sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==
 
+get-user-locale@^2.2.1:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/get-user-locale/-/get-user-locale-2.3.2.tgz#d37ae6e670c2b57d23a96fb4d91e04b2059d52cf"
+  integrity sha512-O2GWvQkhnbDoWFUJfaBlDIKUEdND8ATpBXD6KXcbhxlfktyD/d8w6mkzM/IlQEqGZAMz/PW6j6Hv53BiigKLUQ==
+  dependencies:
+    mem "^8.0.0"
+
 glob-parent@^5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
@@ -1527,7 +1544,7 @@ lodash.merge@^4.6.2:
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
-loose-envify@^1.1.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -1548,6 +1565,21 @@ lru-cache@^5.1.1:
   dependencies:
     yallist "^3.0.2"
 
+map-age-cleaner@^0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz#7d583a7306434c055fe474b0f45078e6e1b4b92a"
+  integrity sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==
+  dependencies:
+    p-defer "^1.0.0"
+
+mem@^8.0.0:
+  version "8.1.1"
+  resolved "https://registry.yarnpkg.com/mem/-/mem-8.1.1.tgz#cf118b357c65ab7b7e0817bdf00c8062297c0122"
+  integrity sha512-qFCFUDs7U3b8mBDPyz5EToEKoAkgCzqquIgi9nkkR9bixxOVOre+09lbuH7+9Kn2NFpm56M3GUWVbU2hQgdACA==
+  dependencies:
+    map-age-cleaner "^0.1.3"
+    mimic-fn "^3.1.0"
+
 merge2@^1.3.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
@@ -1560,6 +1592,11 @@ micromatch@^4.0.4:
   dependencies:
     braces "^3.0.3"
     picomatch "^2.3.1"
+
+mimic-fn@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-3.1.0.tgz#65755145bbf3e36954b949c16450427451d5ca74"
+  integrity sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==
 
 minimatch@^3.1.2:
   version "3.1.2"
@@ -1614,6 +1651,11 @@ optionator@^0.9.3:
     prelude-ls "^1.2.1"
     type-check "^0.4.0"
     word-wrap "^1.2.5"
+
+p-defer@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-defer/-/p-defer-1.0.0.tgz#9f6eb182f6c9aa8cd743004a7d4f96b196b0fb0c"
+  integrity sha512-wB3wfAxZpk2AzOfUMJNL+d36xothRSyj8EXOa4f6GMqYDN9BJaaSISbsk+wS9abmnebVw95C2Kb5t85UmpCxuw==
 
 p-limit@^3.0.2:
   version "3.1.0"
@@ -1699,6 +1741,16 @@ queue-microtask@^1.2.2:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
+
+react-calendar@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/react-calendar/-/react-calendar-5.0.0.tgz#cf302db689ee1bba53d92644f7543e12164a7c0e"
+  integrity sha512-bHcE5e5f+VUKLd4R19BGkcSQLpuwjKBVG0fKz74cwPW5xDfNsReHdDbfd4z3mdjuUuZzVtw4Q920mkwK5/ZOEg==
+  dependencies:
+    "@wojtekmaj/date-utils" "^1.1.3"
+    clsx "^2.0.0"
+    get-user-locale "^2.2.1"
+    warning "^4.0.0"
 
 react-daum-postcode@^3.1.3:
   version "3.1.3"
@@ -1980,6 +2032,13 @@ vite@^5.4.1:
     rollup "^4.20.0"
   optionalDependencies:
     fsevents "~2.3.3"
+
+warning@^4.0.0:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.3.tgz#16e9e077eb8a86d6af7d64aa1e05fd85b4678ca3"
+  integrity sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==
+  dependencies:
+    loose-envify "^1.0.0"
 
 which@^2.0.1:
   version "2.0.2"


### PR DESCRIPTION
<!-- PR의 제목은 "[Feat/#1] 로그인 기능 추가" 와 같이 작성해주세요! -->

## 📌 관련 이슈번호

- Closes #24 
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

## ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. 희망 배송날짜 선택 페이지 컴포넌트 구현
   - react-calendar 라이브러리 사용하여 캘린더 구현 및 스타일 커스텀
   - 선택 날짜 페이지 컴포넌트 내부 state에서 저장 후 다음 버튼 클릭 시 최종 Post 데이터에 저장
   
## 📢 To Reviewers

-

## 📸 스크린샷

<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->
