### PR TITLE
[Feat/#55] 주문번호로 조회 api 연결 완료

### DIFF
--- a/src/apis/domains/orderCheck/useFetchOrderInfoWithOrderNumber.ts
+++ b/src/apis/domains/orderCheck/useFetchOrderInfoWithOrderNumber.ts
@@ -1,0 +1,26 @@
+import { get } from "@apis/api";
+import { QUERY_KEY } from "@apis/queryKeys/queryKeys";
+import { useQuery } from "@tanstack/react-query";
+import { ApiResponseType, OrderInfoData } from "@types";
+
+const getOrderInfo = async (
+  orderNumber: number
+): Promise<OrderInfoData | null> => {
+  try {
+    const response = await get<ApiResponseType<OrderInfoData>>(
+      `api/v1/order/${orderNumber}`
+    );
+    console.log(response.data);
+    return response.data.data;
+  } catch {
+    return null;
+  }
+};
+
+export const useFetchOrderInfoWithOrderNumber = (orderNumber: number) => {
+  return useQuery({
+    queryKey: [QUERY_KEY.ORDER_INFO_WITH_ORDER_NUMBER],
+    queryFn: () => getOrderInfo(orderNumber),
+    enabled: false,
+  });
+};

--- a/src/apis/domains/orderCheck/useFetchOrderInfoWithOrderNumber.ts
+++ b/src/apis/domains/orderCheck/useFetchOrderInfoWithOrderNumber.ts
@@ -10,7 +10,6 @@ const getOrderInfo = async (
     const response = await get<ApiResponseType<OrderInfoData>>(
       `api/v1/order/${orderNumber}`
     );
-    console.log(response.data);
     return response.data.data;
   } catch {
     return null;

--- a/src/apis/queryKeys/queryKeys.ts
+++ b/src/apis/queryKeys/queryKeys.ts
@@ -6,4 +6,5 @@ export const QUERY_KEY = {
   PRODUCT_LIST: "productList",
   PRODUCT_LIST_ALL: "productListAll",
   SAILED_PRODUCT: "sailedProduct",
+  ORDER_INFO_WITH_ORDER_NUMBER: "orderInfoWithOrderNumber",
 } as const;

--- a/src/pages/orderCheck/components/OrderInfoSection/OrderInfoSection.tsx
+++ b/src/pages/orderCheck/components/OrderInfoSection/OrderInfoSection.tsx
@@ -1,3 +1,4 @@
+import { orderInfoAtom, previousOrderNumberAtom } from "@stores";
 import PayButton from "../PayButton/PayButton";
 import {
   blackSpan,
@@ -7,27 +8,34 @@ import {
   section3Div,
   section3InfoWrapper,
 } from "./OrderInfoSection.style";
+import { useAtom } from "jotai";
 
 const OrderInfoSection = () => {
+  const [previousOrderNumber] = useAtom(previousOrderNumberAtom);
+  const [orderInfo] = useAtom(orderInfoAtom);
   return (
     <section css={section3Container}>
       <div css={section3InfoWrapper}>
         <div css={section3Div}>
           <span css={graySpan}>주문번호</span>
-          <span css={blackSpan}>{1004}</span>
+          <span css={blackSpan}>{previousOrderNumber}</span>
         </div>
         <div css={section3Div}>
           <span css={graySpan}>이름</span>
-          <span css={blackSpan}>유태승</span>
+          <span css={blackSpan}>{orderInfo?.senderName}</span>
         </div>
         <div css={section3Div}>
           <span css={graySpan}>상품</span>
-          {/* api 붙이고 수정 */}
-          <span css={blackSpan}>귤 5kg (2박스) 1개</span>
+          {orderInfo?.orderList.map((order, i) => (
+            <span
+              key={i}
+              css={blackSpan}
+            >{`${order.productName} ${order.productCount}개`}</span>
+          ))}
         </div>
         <div css={section3Div}>
           <span css={graySpan}>총 금액</span>
-          <span css={blackSpan}>{"100,000원"}</span>
+          <span css={blackSpan}>{orderInfo?.totalPrice}원</span>
         </div>
       </div>
       <div css={buttonWrapper}>

--- a/src/pages/orderCheck/components/OrderNumberSearchSection/OrderNumberSearchSection.tsx
+++ b/src/pages/orderCheck/components/OrderNumberSearchSection/OrderNumberSearchSection.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import DialButton from "../DialButton/DialButton";
 import {
   dialButtonWrapper,
@@ -7,12 +6,18 @@ import {
   section2Container,
 } from "./OrderNumberSearchSection.style";
 import { useFetchOrderInfoWithOrderNumber } from "@apis/domains/orderCheck/useFetchOrderInfoWithOrderNumber";
+import { useAtom } from "jotai";
+import {
+  orderInfoAtom,
+  orderNumberAtom,
+  previousOrderNumberAtom,
+} from "@stores";
 
 const OrderNumberSearchSection = () => {
-  const [orderNumber, setOrderNumber] = useState("");
-  const { data: orderInfo, refetch } = useFetchOrderInfoWithOrderNumber(
-    Number(orderNumber)
-  );
+  const [orderNumber, setOrderNumber] = useAtom(orderNumberAtom);
+  const [, setOrderInfo] = useAtom(orderInfoAtom);
+  const [, setPreviousOrderNumber] = useAtom(previousOrderNumberAtom);
+  const { refetch } = useFetchOrderInfoWithOrderNumber(Number(orderNumber));
   const handleButtonClick = (value: string) => {
     if (orderNumber.length < 4) {
       setOrderNumber((prev) => prev + value);
@@ -23,11 +28,15 @@ const OrderNumberSearchSection = () => {
     setOrderNumber((prev) => prev.slice(0, -1));
   };
 
-  const handleSearch = () => {
-    refetch();
+  const handleSearch = async () => {
+    const result = await refetch();
+    if (result.data === null) {
+      alert("주문번호에 대한 주문내역이 존재하지 않습니다.");
+    }
+    setOrderInfo(result?.data ?? null);
+    setPreviousOrderNumber(orderNumber);
     setOrderNumber("");
   };
-  console.log(orderInfo);
   return (
     <section css={section2Container}>
       <div css={orderNumberStyle}>

--- a/src/pages/orderCheck/components/OrderNumberSearchSection/OrderNumberSearchSection.tsx
+++ b/src/pages/orderCheck/components/OrderNumberSearchSection/OrderNumberSearchSection.tsx
@@ -6,9 +6,13 @@ import {
   orderNumberStyle,
   section2Container,
 } from "./OrderNumberSearchSection.style";
+import { useFetchOrderInfoWithOrderNumber } from "@apis/domains/orderCheck/useFetchOrderInfoWithOrderNumber";
 
 const OrderNumberSearchSection = () => {
   const [orderNumber, setOrderNumber] = useState("");
+  const { data: orderInfo, refetch } = useFetchOrderInfoWithOrderNumber(
+    Number(orderNumber)
+  );
   const handleButtonClick = (value: string) => {
     if (orderNumber.length < 4) {
       setOrderNumber((prev) => prev + value);
@@ -20,8 +24,10 @@ const OrderNumberSearchSection = () => {
   };
 
   const handleSearch = () => {
-    alert(`조회할 번호: ${orderNumber}`);
+    refetch();
+    setOrderNumber("");
   };
+  console.log(orderInfo);
   return (
     <section css={section2Container}>
       <div css={orderNumberStyle}>

--- a/src/pages/orderCheck/page/OrderCheckPage.tsx
+++ b/src/pages/orderCheck/page/OrderCheckPage.tsx
@@ -1,4 +1,8 @@
-import { iconStyle, orderCheckLayout, refreshButton } from "./OrderCheckPage.style";
+import {
+  iconStyle,
+  orderCheckLayout,
+  refreshButton,
+} from "./OrderCheckPage.style";
 import {
   OrderTrackingSection,
   OrderNumberSearchSection,
@@ -13,7 +17,7 @@ const OrderCheckPage = () => {
       <OrderNumberSearchSection />
       <OrderInfoSection />
       <div css={refreshButton}>
-        <IcRefresh  css={iconStyle}/>
+        <IcRefresh css={iconStyle} />
       </div>
     </div>
   );

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -3,6 +3,9 @@ import { currentRecipient } from "./currentRecipientIndex";
 import { productListAtom } from "./productList";
 import { categoryAtom } from "./category";
 import { orderNumber } from "./orderNumber";
+import { orderNumberAtom } from "./orderInfo";
+import { previousOrderNumberAtom } from "./orderInfo";
+import { orderInfoAtom } from "./orderInfo";
 
 export {
   orderPostAtom,
@@ -10,4 +13,7 @@ export {
   productListAtom,
   categoryAtom,
   orderNumber,
+  orderNumberAtom,
+  previousOrderNumberAtom,
+  orderInfoAtom,
 };

--- a/src/stores/orderInfo.ts
+++ b/src/stores/orderInfo.ts
@@ -1,0 +1,6 @@
+import { OrderInfoData } from "@types";
+import { atom } from "jotai";
+
+export const orderNumberAtom = atom<string>("");
+export const previousOrderNumberAtom = atom<string>("");
+export const orderInfoAtom = atom<OrderInfoData | null>(null);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -3,3 +3,4 @@ export * from "./nextStep";
 export * from "./commonType";
 export * from "./productType";
 export * from "./orderType";
+export * from "./orderInfoWithOrderNumber";

--- a/src/types/orderInfoWithOrderNumber.ts
+++ b/src/types/orderInfoWithOrderNumber.ts
@@ -1,0 +1,12 @@
+export interface OrderInfo {
+  productName: string;
+  productCount: number;
+  orderState: string;
+  price: number;
+}
+
+export interface OrderInfoData {
+  senderName: string;
+  orderList: OrderInfo[];
+  totalPrice: number;
+}


### PR DESCRIPTION
<!-- PR의 제목은 "[Feat/#1] 로그인 기능 추가" 와 같이 작성해주세요! -->

## 📌 관련 이슈번호

- Closes #55 
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

## ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. 테블릿 뷰를 크게 3개의 section으로 나누었고, 이때 두번째와 세번째 section에서 공통적으로 주문번호를 필요로 합니다.
2. 또한 두번째 section의 get api 결과를 세번째 section으로 전달해야해서 jotai로 관리했습니다.
3. 번호 다이얼 누르는곳에서 `조회` 를 클릭해야 get api요청을 해야하기 때문에 refetch로 관리했고, 에러 발생시 alert 띄워주도록 했습니다.
   
## 📢 To Reviewers

-

## 📸 스크린샷

<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->
